### PR TITLE
Improve preview pane appearance

### DIFF
--- a/src/components/preview.rs
+++ b/src/components/preview.rs
@@ -189,12 +189,12 @@ impl Component for Preview {
           ReplaceTextKind::Simple => replace_text.to_string(),
         };
 
-        if replaced_text.len() > 0 {
+        if replaced_text.is_empty() {
+          spans.push(Span::styled(matched_text, Style::default().bg(Color::Blue).add_modifier(Modifier::BOLD)));
+        } else {
           spans
             .push(Span::styled(matched_text, Style::default().bg(Color::LightRed).add_modifier(Modifier::CROSSED_OUT)));
           spans.push(Span::styled(replaced_text, Style::default().fg(Color::White).bg(Color::Green)));
-        } else {
-          spans.push(Span::styled(matched_text, Style::default().bg(Color::Blue).add_modifier(Modifier::BOLD)));
         }
 
         last_end = mat.end;

--- a/src/components/preview.rs
+++ b/src/components/preview.rs
@@ -189,9 +189,14 @@ impl Component for Preview {
           ReplaceTextKind::Simple => replace_text.to_string(),
         };
 
-        spans
-          .push(Span::styled(matched_text, Style::default().fg(Color::LightRed).add_modifier(Modifier::CROSSED_OUT)));
-        spans.push(Span::styled(replaced_text, Style::default().fg(Color::White).bg(Color::Green)));
+        if replaced_text.len() > 0 {
+          spans
+            .push(Span::styled(matched_text, Style::default().bg(Color::LightRed).add_modifier(Modifier::CROSSED_OUT)));
+          spans.push(Span::styled(replaced_text, Style::default().fg(Color::White).bg(Color::Green)));
+        } else {
+          spans.push(Span::styled(matched_text, Style::default().bg(Color::Blue).add_modifier(Modifier::BOLD)));
+        }
+
         last_end = mat.end;
       }
 
@@ -212,7 +217,6 @@ impl Component for Preview {
       if let Some(last) = last_match {
         if line_number > last + 1 {
           let divider_line = Line::from("-".repeat(area.width as usize)).fg(Color::DarkGray);
-          lines.push(divider_line.clone());
           lines.push(divider_line);
         }
       }
@@ -234,7 +238,7 @@ impl Component for Preview {
     let text = Text::from(lines);
 
     let preview_widget =
-      List::new(text).highlight_style(Style::default().bg(Color::Blue)).block(block).scroll_padding(4);
+      List::new(text).highlight_style(Style::default().add_modifier(Modifier::BOLD)).block(block).scroll_padding(4);
 
     f.render_stateful_widget(preview_widget, layout.preview, &mut self.lines_state);
 


### PR DESCRIPTION
Dynamically changes the styles depending on if there is a replace text value, as VS Code does:


https://github.com/yassinebridi/serpl/assets/47499684/9f6083c8-e72e-4e46-9370-e60012a5eb1d

<img width="246" alt="Screenshot 2024-06-28 at 4 59 59 PM" src="https://github.com/yassinebridi/serpl/assets/47499684/33b5e422-6f65-45fe-a629-4bbe63e74079">
<img width="246" alt="Screenshot 2024-06-28 at 5 00 13 PM" src="https://github.com/yassinebridi/serpl/assets/47499684/210ab9c6-a138-444d-bb2e-9d0ef3f9e231">

It was difficult to figure out how to display selected lines but I've gone for bold modifier here. I think it is still not quite visible enough as selected so I'm curious to hear your thoughts on how that can be improved.