### PR TITLE
File by file, and line by line replace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "serpl"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serpl"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "A simple terminal UI for search and replace, ala VS Code"
 repository = "https://github.com/yassinebridi/serpl"

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ https://github.com/yassinebridi/serpl/assets/18403595/348506704-73336074-bfaf-4a
    - [Replace Input](#replace-input)
    - [Search Results Pane](#search-results-pane)
    - [Preview Pane](#preview-pane)
-5. [Neovim Integration using toggleterm](#neovim-integration-using-toggleterm)
-6. [License](#license)
-7. [Contributing](#contributing)
-8. [Acknowledgements](#acknowledgements)
-9. [Similar Projects](#similar-projects)
+5. [Quick Hints](#quick-hints)
+6. [Neovim Integration using toggleterm](#neovim-integration-using-toggleterm)
+7. [License](#license)
+8. [Contributing](#contributing)
+9. [Acknowledgements](#acknowledgements)
+10. [Similar Projects](#similar-projects)
 
 ## Features
 
@@ -115,24 +116,25 @@ Default key bindings can be customized through the `config.json` file.
 
 #### Default Key Bindings
 
-| Key Combination              | Action                            |
-| ---------------------------- | --------------------------------- |
-| `Ctrl + c`                   | Quit                              |
-| `Ctrl + b`                   | Help                              |
-| `Tab`                        | Switch between tabs               |
-| `Backtab`                    | Switch to previous tabs           |
-| `Ctrl + o`                   | Process replace                   |
-| `Ctrl + n`                   | Toggle search and replace modes   |
-| `Enter`                      | Execute search (for large folders)|
-| `g` / `Left` / `h`           | Go to top of the list             |
-| `G` / `Right` / `l`          | Go to bottom of the list          |
-| `j` / `Down`                 | Move to the next item             |
-| `k` / `Up`                   | Move to the previous item         |
-| `d`                          | Delete selected file or line      |
-| `Esc`                        | Exit the current pane or dialog   |
-| `Enter` (in dialogs) / `y`   | Confirm action                    |
-| `Esc` (in dialogs) / `n`     | Cancel action                     |
-| `h`, `l`, `Tab` (in dialogs) | Navigate dialog options           |
+| Key Combination              | Action                                    |
+| ---------------------------- | ----------------------------------------- |
+| `Ctrl + c`                   | Quit                                      |
+| `Ctrl + b`                   | Help                                      |
+| `Tab`                        | Switch between tabs                       |
+| `Backtab`                    | Switch to previous tabs                   |
+| `Ctrl + o`                   | Process replace for all files             |
+| `r`                          | Process replace for selected file or line |
+| `Ctrl + n`                   | Toggle search and replace modes           |
+| `Enter`                      | Execute search (for large folders)        |
+| `g` / `Left` / `h`           | Go to top of the list                     |
+| `G` / `Right` / `l`          | Go to bottom of the list                  |
+| `j` / `Down`                 | Move to the next item                     |
+| `k` / `Up`                   | Move to the previous item                 |
+| `d`                          | Delete selected file or line              |
+| `Esc`                        | Exit the current pane or dialog           |
+| `Enter` (in dialogs) / `y`   | Confirm action                            |
+| `Esc` (in dialogs) / `n`     | Cancel action                             |
+| `h`, `l`, `Tab` (in dialogs) | Navigate dialog options                   |
 
 ### Configuration
 
@@ -214,7 +216,13 @@ You can customize the key bindings by modifying the configuration file in the fo
 ### Search Input
 
 - Input field for entering search keywords.
-- Toggle search modes (Simple, Match Case, Whole Word, Regex, AST Grep).
+- Toggle search modes (Simple, Match Case, Match Whole Word, Match Case Whole Word, Regex, AST Grep).
+  - Simple: Search all occurrences of the keyword.
+  - Match Case: Search occurrences with the same case as the keyword.
+  - Match Whole Word: Search occurrences that match the keyword exactly.
+  - Match Case Whole Word: Search occurrences that match the keyword exactly with the same case.
+  - Regex: Search occurrences using a regular expression.
+  - AST Grep: Search occurrences using AST Grep.
  
 > [!TIP] 
 > If current directory is considerebly large, you have to click `Enter` to start the search.
@@ -223,6 +231,9 @@ You can customize the key bindings by modifying the configuration file in the fo
 
 - Input field for entering replacement text.
 - Toggle replace modes (Simple, Preserve Case, AST Grep).
+  - Simple: Replace all occurrences of the keyword.
+  - Preserve Case: Replace occurrences while preserving the case of the keyword.
+  - AST Grep: Replace occurrences using AST Grep.
 
 ### Search Results Pane
 
@@ -235,6 +246,14 @@ You can customize the key bindings by modifying the configuration file in the fo
 - Display of the selected file with highlighted search results, and context.
 - Navigation to view different matches within the file.
 - Option to delete individual lines containing matches.
+
+## Quick Hints
+- Use the `Ctrl + b` key combination to display the help dialog.
+- Use the `Ctrl + o` key combination to process the replace for all files.
+- Use the `r` key to process the replace for the selected file or line.
+- Use the `Ctrl + n` key combination to toggle between search and replace modes.
+- Use the `g`, `G`, `j`, and `k` keys to navigate through the search results.
+- Use the `d` key to delete the selected file or line.
  
 ## Neovim Integration using toggleterm
 

--- a/src/components/help_dialog.rs
+++ b/src/components/help_dialog.rs
@@ -47,7 +47,7 @@ impl HelpDialog {
   // }
 
   fn global_keybindings() -> String {
-    "- q: Quit\n- Ctrl-c: Quit\n- Ctrl-b: Help dialog\n- Cltr-o: Process Replace\n- Ctrl-n: Loop through search and replace modes\n- Enter: Select/Deselect file\n- d: delete file/delete line from the replace process".to_string()
+    "- q: Quit\n- Ctrl-c: Quit\n- Ctrl-b: Help dialog\n- Cltr-o: Process Replace For All Files\n- Ctrl-n: Loop through search and replace modes\n- Enter: Select/Deselect file\n- d: delete file/delete line from the replace process\n- r: Replace Selected File Or Line".to_string()
   }
 
   fn navigation_keybindings() -> String {

--- a/src/components/preview.rs
+++ b/src/components/preview.rs
@@ -20,7 +20,8 @@ use crate::{
   redux::{
     action::Action,
     state::{FocusedScreen, ReplaceTextKind, SearchResultState, SearchTextKind, State, SubMatch},
-    thunk::ThunkAction, utils::{apply_replace, get_search_regex},
+    thunk::ThunkAction,
+    utils::{apply_replace, get_search_regex},
   },
   tabs::Tab,
 };

--- a/src/components/preview.rs
+++ b/src/components/preview.rs
@@ -99,6 +99,15 @@ impl Preview {
     }
   }
 
+  fn replace_selected_line(&mut self, selected_result_state: &SearchResultState) {
+    if let Some(selected_index) = self.lines_state.selected() {
+      let line_index = self.non_divider_lines.iter().position(|&index| index == selected_index).unwrap_or(0);
+      let file_index = selected_result_state.index.unwrap_or(0);
+      let replace_line_thunk = AppAction::Thunk(ThunkAction::ProcessLineReplace(file_index, line_index));
+      self.command_tx.as_ref().unwrap().send(replace_line_thunk).unwrap();
+    }
+  }
+
   fn format_match_lines<'a>(
     &self,
     full_match: &'a str,
@@ -233,6 +242,10 @@ impl Component for Preview {
         },
         (KeyCode::Char('k') | KeyCode::Up, _) => {
           self.previous();
+          Ok(None)
+        },
+        (KeyCode::Char('r'), _) => {
+          self.replace_selected_line(&state.selected_result);
           Ok(None)
         },
         (KeyCode::Enter, _) | (KeyCode::Esc, _) => {

--- a/src/components/preview.rs
+++ b/src/components/preview.rs
@@ -20,7 +20,7 @@ use crate::{
   redux::{
     action::Action,
     state::{FocusedScreen, ReplaceTextKind, SearchResultState, SearchTextKind, State, SubMatch},
-    thunk::ThunkAction,
+    thunk::ThunkAction, utils::{apply_replace, get_search_regex},
   },
   tabs::Tab,
 };
@@ -108,12 +108,16 @@ impl Preview {
     }
   }
 
+  // disable too_many_arguments clippy
+  #[allow(clippy::too_many_arguments)]
   fn format_match_lines<'a>(
     &self,
     full_match: &'a str,
     submatches: &[SubMatch],
-    replace_text: &'a String,
+    replace_text: &'a str,
     replacement: &'a Option<String>,
+    search_kind: &SearchTextKind,
+    replace_kind: &ReplaceTextKind,
     is_ast_grep: bool,
   ) -> Vec<Line<'a>> {
     let mut lines = Vec::new();
@@ -159,14 +163,31 @@ impl Preview {
 
               spans.push(Span::raw(common_suffix));
             }
-          } else if replace_text.is_empty() {
-            spans.push(Span::styled(matched_text, Style::default().bg(Color::Blue)));
           } else {
-            spans.push(Span::styled(
-              matched_text,
-              Style::default().fg(Color::LightRed).add_modifier(Modifier::CROSSED_OUT),
-            ));
-            spans.push(Span::styled(replace_text, Style::default().fg(Color::White).bg(Color::Green)));
+            let re = get_search_regex(matched_text, search_kind);
+
+            for cap in re.captures_iter(line) {
+              let m = cap.get(0).unwrap();
+              let start = m.start();
+              let end = m.end();
+
+              if start > last_end {
+                spans.push(Span::raw(&line[last_end..start]));
+              }
+
+              if replace_text.is_empty() {
+                spans.push(Span::styled(matched_text, Style::default().bg(Color::Blue)));
+              } else {
+                let replacement = apply_replace(matched_text, replace_text, replace_kind);
+                spans.push(Span::styled(
+                  matched_text,
+                  Style::default().fg(Color::White).bg(Color::LightRed).add_modifier(Modifier::CROSSED_OUT),
+                ));
+                spans.push(Span::styled(replacement, Style::default().fg(Color::White).bg(Color::Green)));
+              }
+
+              last_end = end;
+            }
           }
 
           last_end = end;
@@ -305,6 +326,8 @@ impl Component for Preview {
         &result.submatches,
         &state.replace_text.text,
         &result.replacement,
+        &state.search_text.kind,
+        &state.replace_text.kind,
         is_ast_grep,
       );
       for (i, formatted_line) in formatted_lines.clone().into_iter().enumerate() {

--- a/src/components/replace.rs
+++ b/src/components/replace.rs
@@ -58,6 +58,9 @@ impl Replace {
     if replace_text_kind == ReplaceTextKind::AstGrep {
       let search_text_action = AppAction::Action(Action::SetSearchTextKind { kind: SearchTextKind::AstGrep });
       self.command_tx.as_ref().unwrap().send(search_text_action).unwrap();
+    } else if replace_text_kind != ReplaceTextKind::AstGrep {
+      let search_text_action = AppAction::Action(Action::SetSearchTextKind { kind: SearchTextKind::Simple });
+      self.command_tx.as_ref().unwrap().send(search_text_action).unwrap();
     }
 
     let process_search_thunk = AppAction::Thunk(ThunkAction::ProcessSearch);

--- a/src/components/search.rs
+++ b/src/components/search.rs
@@ -85,6 +85,9 @@ impl Search {
     if search_text_kind == SearchTextKind::AstGrep {
       let replace_text_action = AppAction::Action(Action::SetReplaceTextKind { kind: ReplaceTextKind::AstGrep });
       self.command_tx.as_ref().unwrap().send(replace_text_action).unwrap();
+    } else if state.replace_text.kind == ReplaceTextKind::AstGrep {
+      let replace_text_action = AppAction::Action(Action::SetReplaceTextKind { kind: ReplaceTextKind::Simple });
+      self.command_tx.as_ref().unwrap().send(replace_text_action).unwrap();
     }
 
     let process_search_thunk = AppAction::Thunk(ThunkAction::ProcessSearch);

--- a/src/components/search_result.rs
+++ b/src/components/search_result.rs
@@ -180,6 +180,15 @@ impl SearchResult {
     self.match_counts.push(total_matches_str);
     self.match_counts.last().unwrap()
   }
+
+  fn replace_single_file(&mut self, state: &State) {
+    if let Some(selected_index) = self.state.selected() {
+      if selected_index < state.search_result.list.len() {
+        let process_single_file_replace_thunk = AppAction::Thunk(ThunkAction::ProcessSingleFileReplace(selected_index));
+        self.command_tx.as_ref().unwrap().send(process_single_file_replace_thunk).unwrap();
+      }
+    }
+  }
 }
 
 impl Component for SearchResult {
@@ -214,6 +223,10 @@ impl Component for SearchResult {
         },
         (KeyCode::Char('k') | KeyCode::Up, _) => {
           self.previous(state);
+          Ok(None)
+        },
+        (KeyCode::Char('r'), _) => {
+          self.replace_single_file(state);
           Ok(None)
         },
         (KeyCode::Enter, _) => {

--- a/src/components/small_help.rs
+++ b/src/components/small_help.rs
@@ -55,10 +55,10 @@ impl Component for SmallHelp {
   fn draw(&mut self, f: &mut Frame<'_>, area: Rect, state: &State) -> Result<()> {
     let layout = get_layout(area);
     let content = match state.focused_screen {
-      FocusedScreen::SearchInput => "Help: <Ctrl-b> | Search: <Enter> | Switch to Replace: <Tab> | Toggle search mode: <Ctrl-n>",
-      FocusedScreen::ReplaceInput => "Help: <Ctrl-b> | Replace: <C-o> | Switch to Search List: <Tab> | Toggle replace mode: <Ctrl-n>",
-      FocusedScreen::SearchResultList => "Help: <Ctrl-b> | Open File: <Enter> | Switch to Search: <Tab> | Next: <j> | Previous: <k> | Top: <g> | Bottom: <G> | Delete file: <d>",
-      FocusedScreen::Preview => "Help: <Ctrl-b> | Back to list: <Enter> | Switch to Search: <Tab> | Next: <j> | Previous: <k> | Top: <g> | Bottom: <G> | Delete line: <d>",
+      FocusedScreen::SearchInput => "Help: <Ctrl-b> | Search: <Enter> | Toggle search mode: <Ctrl-n>",
+      FocusedScreen::ReplaceInput => "Help: <Ctrl-b> | Replace: <C-o> | Toggle replace mode: <Ctrl-n>",
+      FocusedScreen::SearchResultList => "Help: <Ctrl-b> | Open File: <Enter> | Replace File: <r> | Next: <j> | Previous: <k> | Top: <g> | Bottom: <G> | Delete file: <d>",
+      FocusedScreen::Preview => "Help: <Ctrl-b> | Back to list: <Enter> | Replace Line: <r> | Next: <j> | Previous: <k> | Top: <g> | Bottom: <G> | Delete line: <d>",
       FocusedScreen::ConfirmReplaceDialog => "Confirm Replace: <Enter> | Cancel Replace: <Esc>, Left: <h>, Right: <l>, Loop: <Tab>",
       FocusedScreen::ConfirmGitDirectoryDialog => "Confirm Replace: <Enter> | Cancel Replace: <Esc>, Left: <h>, Right: <l>, Loop: <Tab>",
       FocusedScreen::HelpDialog => "Close Help: <Esc> | Next Tab: <Right> | Previous Tab: <Left>",

--- a/src/redux.rs
+++ b/src/redux.rs
@@ -2,6 +2,7 @@ pub mod action;
 pub mod reducer;
 pub mod state;
 pub mod thunk;
+pub mod utils;
 
 #[derive(Debug)]
 pub enum ActionOrThunk {

--- a/src/redux/action.rs
+++ b/src/redux/action.rs
@@ -31,4 +31,5 @@ pub enum Action {
   SetDialog { dialog: Option<Dialog> },
   SetFocusedScreen { screen: Option<FocusedScreen> },
   RemoveFileFromList { index: usize },
+  RemoveLineFromFile { file_index: usize, line_index: usize },
 }

--- a/src/redux/action.rs
+++ b/src/redux/action.rs
@@ -30,4 +30,5 @@ pub enum Action {
   SetNotification { message: String, show: bool, ttl: u64, color: Color },
   SetDialog { dialog: Option<Dialog> },
   SetFocusedScreen { screen: Option<FocusedScreen> },
+  RemoveFileFromList { index: usize },
 }

--- a/src/redux/reducer.rs
+++ b/src/redux/reducer.rs
@@ -134,6 +134,13 @@ pub fn reducer(state: State, action: Action) -> State {
         ..state
       }
     },
+    Action::RemoveFileFromList { index } => {
+      let mut new_search_result = state.search_result.clone();
+      if index < new_search_result.list.len() {
+        new_search_result.list.remove(index);
+      }
+      State { search_result: new_search_result, ..state }
+    },
   }
 }
 

--- a/src/redux/reducer.rs
+++ b/src/redux/reducer.rs
@@ -141,6 +141,34 @@ pub fn reducer(state: State, action: Action) -> State {
       }
       State { search_result: new_search_result, ..state }
     },
+
+    Action::RemoveLineFromFile { file_index, line_index } => {
+      let mut new_search_result = state.search_result.clone();
+      if file_index < new_search_result.list.len() {
+        let file_result = &mut new_search_result.list[file_index];
+        if line_index < file_result.matches.len() {
+          file_result.matches.remove(line_index);
+          file_result.total_matches -= 1;
+
+          if file_result.matches.is_empty() {
+            new_search_result.list.remove(file_index);
+          }
+
+          let new_selected_result = if !new_search_result.list.is_empty() {
+            let new_selected_index = file_index.min(new_search_result.list.len() - 1);
+            new_search_result.list[new_selected_index].clone()
+          } else {
+            SearchResultState::default()
+          };
+
+          State { search_result: new_search_result, selected_result: new_selected_result, ..state }
+        } else {
+          state
+        }
+      } else {
+        state
+      }
+    },
   }
 }
 

--- a/src/redux/thunk.rs
+++ b/src/redux/thunk.rs
@@ -7,6 +7,7 @@ use super::{action::Action, state::State};
 use crate::action::{AppAction, TuiAction};
 
 pub mod process_replace;
+pub mod process_single_file_replace;
 pub mod process_search;
 pub mod remove_file_from_list;
 pub mod remove_line_from_file;
@@ -17,6 +18,7 @@ pub enum ThunkAction {
   ProcessReplace(ForceReplace),
   RemoveFileFromList(usize),
   RemoveLineFromFile(usize, usize),
+  ProcessSingleFileReplace(usize),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -33,6 +35,9 @@ where
     ThunkAction::ProcessSearch => Box::new(process_search::ProcessSearchThunk::new()),
     ThunkAction::ProcessReplace(force_replace) => {
       Box::new(process_replace::ProcessReplaceThunk::new(command_tx, force_replace))
+    },
+    ThunkAction::ProcessSingleFileReplace(index) => {
+      Box::new(process_single_file_replace::ProcessSingleFileReplaceThunk::new(command_tx, index))
     },
     ThunkAction::RemoveFileFromList(index) => Box::new(remove_file_from_list::RemoveFileFromListThunk::new(index)),
     ThunkAction::RemoveLineFromFile(file_index, line_index) => {

--- a/src/redux/thunk.rs
+++ b/src/redux/thunk.rs
@@ -6,9 +6,10 @@ use tokio::sync::mpsc::UnboundedSender;
 use super::{action::Action, state::State};
 use crate::action::{AppAction, TuiAction};
 
+pub mod process_line_replace;
 pub mod process_replace;
-pub mod process_single_file_replace;
 pub mod process_search;
+pub mod process_single_file_replace;
 pub mod remove_file_from_list;
 pub mod remove_line_from_file;
 
@@ -19,6 +20,7 @@ pub enum ThunkAction {
   RemoveFileFromList(usize),
   RemoveLineFromFile(usize, usize),
   ProcessSingleFileReplace(usize),
+  ProcessLineReplace(usize, usize),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -38,6 +40,9 @@ where
     },
     ThunkAction::ProcessSingleFileReplace(index) => {
       Box::new(process_single_file_replace::ProcessSingleFileReplaceThunk::new(command_tx, index))
+    },
+    ThunkAction::ProcessLineReplace(file_index, line_index) => {
+      Box::new(process_line_replace::ProcessLineReplaceThunk::new(command_tx, file_index, line_index))
     },
     ThunkAction::RemoveFileFromList(index) => Box::new(remove_file_from_list::RemoveFileFromListThunk::new(index)),
     ThunkAction::RemoveLineFromFile(file_index, line_index) => {

--- a/src/redux/thunk/process_line_replace.rs
+++ b/src/redux/thunk/process_line_replace.rs
@@ -1,16 +1,18 @@
-use std::{fs, sync::Arc};
+use std::{fs, process::Command, sync::Arc};
 
 use async_trait::async_trait;
 use redux_rs::{middlewares::thunk::Thunk, StoreApi};
 use regex::RegexBuilder;
+use serde_json::from_str;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
   action::{AppAction, TuiAction},
+  astgrep::AstGrepOutput,
   components::notifications::NotificationEnum,
   redux::{
     action::Action,
-    state::{ReplaceTextKind, SearchTextKind, State},
+    state::{Match, ReplaceTextKind, ReplaceTextState, SearchTextKind, SearchTextState, State},
     thunk::ThunkAction,
   },
 };
@@ -34,73 +36,122 @@ impl ProcessLineReplaceThunk {
     if let Some(search_result) = search_list.list.get(self.file_index) {
       if let Some(match_info) = search_result.matches.get(self.line_index) {
         let file_path = &search_result.path;
-        let content = fs::read_to_string(file_path).expect("Unable to read file");
-        let mut lines: Vec<String> = content.lines().map(String::from).collect();
 
-        let re = match search_text_state.kind {
-          SearchTextKind::Regex => {
-            RegexBuilder::new(&search_text_state.text).case_insensitive(true).build().expect("Invalid regex")
-          },
-          SearchTextKind::MatchCase => {
-            RegexBuilder::new(&regex::escape(&search_text_state.text))
-              .case_insensitive(false)
-              .build()
-              .expect("Invalid regex")
-          },
-          SearchTextKind::MatchWholeWord => {
-            RegexBuilder::new(&format!(r"\b{}\b", regex::escape(&search_text_state.text)))
-              .case_insensitive(true)
-              .build()
-              .expect("Invalid regex")
-          },
-          SearchTextKind::MatchCaseWholeWord => {
-            RegexBuilder::new(&format!(r"\b{}\b", regex::escape(&search_text_state.text)))
-              .case_insensitive(false)
-              .build()
-              .expect("Invalid regex")
-          },
-          SearchTextKind::Simple => {
-            RegexBuilder::new(&regex::escape(&search_text_state.text))
-              .case_insensitive(true)
-              .build()
-              .expect("Invalid regex")
-          },
-          #[cfg(feature = "ast_grep")]
-          SearchTextKind::AstGrep => panic!("AST-grep is not supported for line-by-line replacement"),
-        };
-
-        if let Some(line) = lines.get_mut(match_info.line_number - 1) {
-          let replaced_line = re.replace_all(line, |caps: &regex::Captures| {
-            let matched_text = caps.get(0).unwrap().as_str();
-            match replace_text_state.kind {
-              ReplaceTextKind::PreserveCase => {
-                let first_char = matched_text.chars().next().unwrap_or_default();
-                if matched_text.chars().all(char::is_uppercase) {
-                  replace_text_state.text.to_uppercase()
-                } else if first_char.is_uppercase() {
-                  replace_text_state
-                    .text
-                    .chars()
-                    .enumerate()
-                    .map(|(i, rc)| if i == 0 { rc.to_uppercase().to_string() } else { rc.to_lowercase().to_string() })
-                    .collect::<String>()
-                } else {
-                  replace_text_state.text.to_lowercase()
-                }
-              },
-              ReplaceTextKind::Simple => replace_text_state.text.to_string(),
-              #[cfg(feature = "ast_grep")]
-              ReplaceTextKind::AstGrep => panic!("AST-grep is not supported for line-by-line replacement"),
-            }
-          });
-          *line = replaced_line.into_owned();
+        #[cfg(feature = "ast_grep")]
+        if search_text_state.kind == SearchTextKind::AstGrep {
+          self
+            .process_ast_grep_replace(
+              file_path,
+              &search_text_state.text,
+              &replace_text_state.text,
+              match_info.line_number,
+            )
+            .await;
+        } else {
+          process_normal_replace(search_text_state, match_info, replace_text_state, file_path);
         }
 
-        let new_content = lines.join("\n");
-        fs::write(file_path, new_content).expect("Unable to write file");
+        #[cfg(not(feature = "ast_grep"))]
+        process_normal_replace(search_text_state, match_info, replace_text_state, file_path);
       }
     }
   }
+
+  async fn process_ast_grep_replace(
+    &self,
+    file_path: &str,
+    search_pattern: &str,
+    replace_pattern: &str,
+    line_number: usize,
+  ) {
+    let output = Command::new("ast-grep")
+      .args(["run", "-p", search_pattern, "-r", replace_pattern, "--json=compact", file_path])
+      .output()
+      .expect("Failed to execute ast-grep for replacement");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let ast_grep_results: Vec<AstGrepOutput> = from_str(&stdout).expect("Failed to parse ast-grep output");
+
+    let mut content = fs::read_to_string(file_path).expect("Unable to read file");
+
+    for result in ast_grep_results.iter().rev() {
+      if result.range.start.line == line_number {
+        if let (Some(replacement), Some(offsets)) = (&result.replacement, &result.replacement_offsets) {
+          let start = offsets.start;
+          let end = offsets.end;
+          content.replace_range(start..end, replacement);
+        }
+      }
+    }
+
+    fs::write(file_path, content).expect("Unable to write file");
+  }
+}
+
+fn process_normal_replace(
+  search_text_state: SearchTextState,
+  match_info: &Match,
+  replace_text_state: ReplaceTextState,
+  file_path: &str,
+) {
+  let content = fs::read_to_string(file_path).expect("Unable to read file");
+  let mut lines: Vec<String> = content.lines().map(String::from).collect();
+
+  let re = match search_text_state.kind {
+    SearchTextKind::Regex => {
+      RegexBuilder::new(&search_text_state.text).case_insensitive(true).build().expect("Invalid regex")
+    },
+    SearchTextKind::MatchCase => {
+      RegexBuilder::new(&regex::escape(&search_text_state.text)).case_insensitive(false).build().expect("Invalid regex")
+    },
+    SearchTextKind::MatchWholeWord => {
+      RegexBuilder::new(&format!(r"\\b{}\\b", regex::escape(&search_text_state.text)))
+        .case_insensitive(true)
+        .build()
+        .expect("Invalid regex")
+    },
+    SearchTextKind::MatchCaseWholeWord => {
+      RegexBuilder::new(&format!(r"\\b{}\\b", regex::escape(&search_text_state.text)))
+        .case_insensitive(false)
+        .build()
+        .expect("Invalid regex")
+    },
+    SearchTextKind::Simple => {
+      RegexBuilder::new(&regex::escape(&search_text_state.text)).case_insensitive(true).build().expect("Invalid regex")
+    },
+    #[cfg(feature = "ast_grep")]
+    SearchTextKind::AstGrep => unreachable!(),
+  };
+
+  if let Some(line) = lines.get_mut(match_info.line_number - 1) {
+    let replaced_line = re.replace_all(line, |caps: &regex::Captures| {
+      let matched_text = caps.get(0).unwrap().as_str();
+      match replace_text_state.kind {
+        ReplaceTextKind::PreserveCase => {
+          let first_char = matched_text.chars().next().unwrap_or_default();
+          if matched_text.chars().all(char::is_uppercase) {
+            replace_text_state.text.to_uppercase()
+          } else if first_char.is_uppercase() {
+            replace_text_state
+              .text
+              .chars()
+              .enumerate()
+              .map(|(i, rc)| if i == 0 { rc.to_uppercase().to_string() } else { rc.to_lowercase().to_string() })
+              .collect::<String>()
+          } else {
+            replace_text_state.text.to_lowercase()
+          }
+        },
+        ReplaceTextKind::Simple => replace_text_state.text.to_string(),
+        #[cfg(feature = "ast_grep")]
+        ReplaceTextKind::AstGrep => unreachable!(),
+      }
+    });
+    *line = replaced_line.into_owned();
+  }
+
+  let new_content = lines.join("\n");
+  fs::write(file_path, new_content).expect("Unable to write file");
 }
 
 #[async_trait]

--- a/src/redux/thunk/process_line_replace.rs
+++ b/src/redux/thunk/process_line_replace.rs
@@ -1,0 +1,126 @@
+use std::{fs, sync::Arc};
+
+use async_trait::async_trait;
+use redux_rs::{middlewares::thunk::Thunk, StoreApi};
+use regex::RegexBuilder;
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::{
+  action::{AppAction, TuiAction},
+  components::notifications::NotificationEnum,
+  redux::{
+    action::Action,
+    state::{ReplaceTextKind, SearchTextKind, State},
+    thunk::ThunkAction,
+  },
+};
+
+pub struct ProcessLineReplaceThunk {
+  command_tx: Arc<UnboundedSender<AppAction>>,
+  file_index: usize,
+  line_index: usize,
+}
+
+impl ProcessLineReplaceThunk {
+  pub fn new(command_tx: Arc<UnboundedSender<AppAction>>, file_index: usize, line_index: usize) -> Self {
+    Self { command_tx, file_index, line_index }
+  }
+
+  async fn process_replace_line(&self, store: &Arc<impl StoreApi<State, Action> + Send + Sync + 'static>) {
+    let search_list = store.select(|state: &State| state.search_result.clone()).await;
+    let search_text_state = store.select(|state: &State| state.search_text.clone()).await;
+    let replace_text_state = store.select(|state: &State| state.replace_text.clone()).await;
+
+    if let Some(search_result) = search_list.list.get(self.file_index) {
+      if let Some(match_info) = search_result.matches.get(self.line_index) {
+        let file_path = &search_result.path;
+        let content = fs::read_to_string(file_path).expect("Unable to read file");
+        let mut lines: Vec<String> = content.lines().map(String::from).collect();
+
+        let re = match search_text_state.kind {
+          SearchTextKind::Regex => {
+            RegexBuilder::new(&search_text_state.text).case_insensitive(true).build().expect("Invalid regex")
+          },
+          SearchTextKind::MatchCase => {
+            RegexBuilder::new(&regex::escape(&search_text_state.text))
+              .case_insensitive(false)
+              .build()
+              .expect("Invalid regex")
+          },
+          SearchTextKind::MatchWholeWord => {
+            RegexBuilder::new(&format!(r"\b{}\b", regex::escape(&search_text_state.text)))
+              .case_insensitive(true)
+              .build()
+              .expect("Invalid regex")
+          },
+          SearchTextKind::MatchCaseWholeWord => {
+            RegexBuilder::new(&format!(r"\b{}\b", regex::escape(&search_text_state.text)))
+              .case_insensitive(false)
+              .build()
+              .expect("Invalid regex")
+          },
+          SearchTextKind::Simple => {
+            RegexBuilder::new(&regex::escape(&search_text_state.text))
+              .case_insensitive(true)
+              .build()
+              .expect("Invalid regex")
+          },
+          #[cfg(feature = "ast_grep")]
+          SearchTextKind::AstGrep => panic!("AST-grep is not supported for line-by-line replacement"),
+        };
+
+        if let Some(line) = lines.get_mut(match_info.line_number - 1) {
+          let replaced_line = re.replace_all(line, |caps: &regex::Captures| {
+            let matched_text = caps.get(0).unwrap().as_str();
+            match replace_text_state.kind {
+              ReplaceTextKind::PreserveCase => {
+                let first_char = matched_text.chars().next().unwrap_or_default();
+                if matched_text.chars().all(char::is_uppercase) {
+                  replace_text_state.text.to_uppercase()
+                } else if first_char.is_uppercase() {
+                  replace_text_state
+                    .text
+                    .chars()
+                    .enumerate()
+                    .map(|(i, rc)| if i == 0 { rc.to_uppercase().to_string() } else { rc.to_lowercase().to_string() })
+                    .collect::<String>()
+                } else {
+                  replace_text_state.text.to_lowercase()
+                }
+              },
+              ReplaceTextKind::Simple => replace_text_state.text.to_string(),
+              #[cfg(feature = "ast_grep")]
+              ReplaceTextKind::AstGrep => panic!("AST-grep is not supported for line-by-line replacement"),
+            }
+          });
+          *line = replaced_line.into_owned();
+        }
+
+        let new_content = lines.join("\n");
+        fs::write(file_path, new_content).expect("Unable to write file");
+      }
+    }
+  }
+}
+
+#[async_trait]
+impl<Api> Thunk<State, Action, Api> for ProcessLineReplaceThunk
+where
+  Api: StoreApi<State, Action> + Send + Sync + 'static,
+{
+  async fn execute(&self, store: Arc<Api>) {
+    let processing_status_action = AppAction::Tui(TuiAction::Status("Processing line replacement...".to_string()));
+    self.command_tx.send(processing_status_action).unwrap();
+
+    self.process_replace_line(&store).await;
+
+    store.dispatch(Action::RemoveLineFromFile { file_index: self.file_index, line_index: self.line_index }).await;
+
+    let done_processing_status_action = AppAction::Tui(TuiAction::Status("".to_string()));
+    self.command_tx.send(done_processing_status_action).unwrap();
+
+    let notification_action =
+      AppAction::Tui(TuiAction::Notify(NotificationEnum::Info("Line replacement completed successfully".to_string())));
+    self.command_tx.send(notification_action).unwrap();
+  }
+}

--- a/src/redux/thunk/process_replace.rs
+++ b/src/redux/thunk/process_replace.rs
@@ -19,6 +19,7 @@ use crate::{
     action::Action,
     state::{ConfirmDialogState, Dialog, DialogAction, ReplaceTextKind, SearchTextKind, State},
     thunk::{ForceReplace, ThunkAction},
+    utils::{replace_file_ast, replace_file_normal},
   },
   utils::is_git_repo,
 };
@@ -39,32 +40,7 @@ impl ProcessReplaceThunk {
     let replace_text_state = store.select(|state: &State| state.replace_text.clone()).await;
 
     for search_result in &search_list.list {
-      let file_path = &search_result.path;
-
-      let mut content = fs::read_to_string(file_path).expect("Unable to read file");
-      let lines: Vec<&str> = content.lines().collect();
-
-      let lines_to_replace: HashSet<usize> = search_result.matches.iter().map(|m| m.line_number).collect();
-
-      let output = Command::new("ast-grep")
-        .args(["run", "-p", &search_text_state.text, "-r", &replace_text_state.text, "--json=compact", file_path])
-        .output()
-        .expect("Failed to execute ast-grep for replacement");
-
-      let stdout = String::from_utf8_lossy(&output.stdout);
-      let ast_grep_results: Vec<AstGrepOutput> = from_str(&stdout).expect("Failed to parse ast-grep output");
-
-      for result in ast_grep_results.iter().rev() {
-        if let (Some(replacement), Some(offsets)) = (&result.replacement, &result.replacement_offsets) {
-          if lines_to_replace.contains(&result.range.start.line) {
-            let start = offsets.start;
-            let end = offsets.end;
-            content.replace_range(start..end, replacement);
-          }
-        }
-      }
-
-      fs::write(file_path, content).expect("Unable to write file");
+      replace_file_ast(search_result, &search_text_state, &replace_text_state);
     }
   }
 
@@ -109,57 +85,7 @@ impl ProcessReplaceThunk {
     };
 
     for search_result in &search_list.list {
-      let file_path = &search_result.path;
-
-      let content = fs::read_to_string(file_path).expect("Unable to read file");
-
-      let mut new_content = String::new();
-
-      let mut last_end = 0;
-
-      for mat in &search_result.matches {
-        let line_number = mat.line_number;
-        let line_start = content.lines().take(line_number - 1).map(|line| line.len() + 1).sum::<usize>();
-        let line_end = line_start + mat.lines.as_ref().unwrap().text.len();
-
-        new_content.push_str(&content[last_end..line_start]);
-
-        let line = mat.lines.as_ref().unwrap().text.clone();
-        let replaced_line = re
-          .replace_all(&line, |caps: &regex::Captures| {
-            let matched_text = caps.get(0).unwrap().as_str();
-            match replace_text_state.kind {
-              ReplaceTextKind::PreserveCase => {
-                let first_char = matched_text.chars().next().unwrap_or_default();
-                if matched_text.chars().all(char::is_uppercase) {
-                  replace_text_state.text.to_uppercase()
-                } else if first_char.is_uppercase() {
-                  replace_text_state
-                    .text
-                    .chars()
-                    .enumerate()
-                    .map(|(i, rc)| if i == 0 { rc.to_uppercase().to_string() } else { rc.to_lowercase().to_string() })
-                    .collect::<String>()
-                } else {
-                  replace_text_state.text.to_lowercase()
-                }
-              },
-              ReplaceTextKind::Simple => replace_text_state.text.to_string(),
-              #[cfg(feature = "ast_grep")]
-              ReplaceTextKind::AstGrep => panic!(),
-            }
-          })
-          .to_string();
-
-        new_content.push_str(&replaced_line);
-
-        last_end = line_end;
-      }
-
-      new_content.push_str(&content[last_end..]);
-
-      let mut file = fs::OpenOptions::new().write(true).truncate(true).open(file_path).expect("Unable to open file");
-      file.write_all(new_content.as_bytes()).expect("Unable to write file");
+      replace_file_normal(search_result, &search_text_state, &replace_text_state);
     }
   }
 

--- a/src/redux/thunk/process_search.rs
+++ b/src/redux/thunk/process_search.rs
@@ -127,7 +127,7 @@ impl ProcessSearchThunk {
       SearchTextKind::MatchCase => rg_args.extend(&["-s", &search_text_state.text]),
       SearchTextKind::MatchWholeWord => rg_args.extend(&["-w", "-i", &search_text_state.text]),
       SearchTextKind::MatchCaseWholeWord => rg_args.extend(&["-w", "-s", &search_text_state.text]),
-      SearchTextKind::Simple => rg_args.extend(&["-i", &search_text_state.text]),
+      SearchTextKind::Simple => rg_args.extend(&["-i", "-F", &search_text_state.text]),
       #[cfg(feature = "ast_grep")]
       SearchTextKind::AstGrep => {},
     }

--- a/src/redux/thunk/process_single_file_replace.rs
+++ b/src/redux/thunk/process_single_file_replace.rs
@@ -1,0 +1,86 @@
+use std::{collections::HashSet, fs, io::Write, path::PathBuf, process::Command, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use color_eyre::eyre::Result;
+use ratatui::style::Color;
+use redux_rs::{
+  middlewares::thunk::{self, Thunk},
+  StoreApi,
+};
+use regex::RegexBuilder;
+use serde_json::from_str;
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::{
+  action::{AppAction, TuiAction},
+  astgrep::AstGrepOutput,
+  components::notifications::NotificationEnum,
+  redux::{
+    action::Action,
+    state::{ConfirmDialogState, Dialog, DialogAction, ReplaceTextKind, SearchTextKind, State},
+    thunk::{ForceReplace, ThunkAction},
+    utils::{replace_file_ast, replace_file_normal},
+  },
+  utils::is_git_repo,
+};
+
+pub struct ProcessSingleFileReplaceThunk {
+  command_tx: Arc<UnboundedSender<AppAction>>,
+  file_index: usize,
+}
+
+impl ProcessSingleFileReplaceThunk {
+  pub fn new(command_tx: Arc<UnboundedSender<AppAction>>, file_index: usize) -> Self {
+    Self { command_tx, file_index }
+  }
+
+  async fn process_ast_grep_replace(&self, store: &Arc<impl StoreApi<State, Action> + Send + Sync + 'static>) {
+    let search_list = store.select(|state: &State| state.search_result.clone()).await;
+    let search_text_state = store.select(|state: &State| state.search_text.clone()).await;
+    let replace_text_state = store.select(|state: &State| state.replace_text.clone()).await;
+
+    if let Some(search_result) = search_list.list.get(self.file_index) {
+      replace_file_ast(search_result, &search_text_state, &replace_text_state);
+    }
+  }
+
+  async fn process_normal_replace(&self, store: &Arc<impl StoreApi<State, Action> + Send + Sync + 'static>) {
+    let search_list = store.select(|state: &State| state.search_result.clone()).await;
+    let search_text_state = store.select(|state: &State| state.search_text.clone()).await;
+    let replace_text_state = store.select(|state: &State| state.replace_text.clone()).await;
+
+    if let Some(search_result) = search_list.list.get(self.file_index) {
+      replace_file_normal(search_result, &search_text_state, &replace_text_state);
+    }
+  }
+}
+
+#[async_trait]
+impl<Api> Thunk<State, Action, Api> for ProcessSingleFileReplaceThunk
+where
+  Api: StoreApi<State, Action> + Send + Sync + 'static,
+{
+  async fn execute(&self, store: Arc<Api>) {
+    let search_text_state = store.select(|state: &State| state.search_text.clone()).await;
+    let replace_text_state = store.select(|state: &State| state.replace_text.clone()).await;
+
+    #[cfg(feature = "ast_grep")]
+    if search_text_state.kind == SearchTextKind::AstGrep {
+      self.process_ast_grep_replace(&store).await;
+    } else {
+      self.process_normal_replace(&store).await;
+    }
+
+    #[cfg(not(feature = "ast_grep"))]
+    self.process_normal_replace(&store).await;
+
+    store.dispatch(Action::RemoveFileFromList { index: self.file_index }).await;
+
+    let done_processing_status_action = AppAction::Tui(TuiAction::Status("".to_string()));
+    self.command_tx.send(done_processing_status_action).unwrap();
+
+    let notification_action =
+      AppAction::Tui(TuiAction::Notify(NotificationEnum::Info("File replacement completed successfully".to_string())));
+    self.command_tx.send(notification_action).unwrap();
+  }
+}

--- a/src/redux/utils.rs
+++ b/src/redux/utils.rs
@@ -1,0 +1,107 @@
+use std::fs;
+
+use regex::RegexBuilder;
+use serde_json::from_str;
+
+use crate::{
+  astgrep::AstGrepOutput,
+  redux::state::{ReplaceTextKind, SearchTextKind},
+};
+
+pub fn replace_file_ast(
+  search_result: &crate::redux::state::SearchResultState,
+  search_text_state: &crate::redux::state::SearchTextState,
+  replace_text_state: &crate::redux::state::ReplaceTextState,
+) {
+  let file_path = &search_result.path;
+
+  let mut content = fs::read_to_string(file_path).expect("Unable to read file");
+  let lines: Vec<&str> = content.lines().collect();
+
+  let lines_to_replace: std::collections::HashSet<usize> =
+    search_result.matches.iter().map(|m| m.line_number).collect();
+
+  let output = std::process::Command::new("ast-grep")
+    .args(["run", "-p", &search_text_state.text, "-r", &replace_text_state.text, "--json=compact", file_path])
+    .output()
+    .expect("Failed to execute ast-grep for replacement");
+
+  let stdout = String::from_utf8_lossy(&output.stdout);
+  let ast_grep_results: Vec<AstGrepOutput> = from_str(&stdout).expect("Failed to parse ast-grep output");
+
+  for result in ast_grep_results.iter().rev() {
+    if let (Some(replacement), Some(offsets)) = (&result.replacement, &result.replacement_offsets) {
+      if lines_to_replace.contains(&result.range.start.line) {
+        let start = offsets.start;
+        let end = offsets.end;
+        content.replace_range(start..end, replacement);
+      }
+    }
+  }
+
+  fs::write(file_path, content).expect("Unable to write file");
+}
+
+pub fn replace_file_normal(
+  search_result: &crate::redux::state::SearchResultState,
+  search_text_state: &crate::redux::state::SearchTextState,
+  replace_text_state: &crate::redux::state::ReplaceTextState,
+) {
+  let file_path = &search_result.path;
+
+  let content = fs::read_to_string(file_path).expect("Unable to read file");
+
+  let re = match search_text_state.kind {
+    SearchTextKind::Regex => {
+      RegexBuilder::new(&search_text_state.text).case_insensitive(true).build().expect("Invalid regex")
+    },
+    SearchTextKind::MatchCase => {
+      RegexBuilder::new(&regex::escape(&search_text_state.text)).case_insensitive(false).build().expect("Invalid regex")
+    },
+    SearchTextKind::MatchWholeWord => {
+      RegexBuilder::new(&format!(r"\\b{}\\b", regex::escape(&search_text_state.text)))
+        .case_insensitive(true)
+        .build()
+        .expect("Invalid regex")
+    },
+    SearchTextKind::MatchCaseWholeWord => {
+      RegexBuilder::new(&format!(r"\\b{}\\b", regex::escape(&search_text_state.text)))
+        .case_insensitive(false)
+        .build()
+        .expect("Invalid regex")
+    },
+    SearchTextKind::Simple => {
+      RegexBuilder::new(&regex::escape(&search_text_state.text)).case_insensitive(true).build().expect("Invalid regex")
+    },
+    #[cfg(feature = "ast_grep")]
+    SearchTextKind::AstGrep => panic!("AST-grep should not be handled here"),
+  };
+
+  let new_content = re
+    .replace_all(&content, |caps: &regex::Captures| {
+      let matched_text = caps.get(0).unwrap().as_str();
+      match replace_text_state.kind {
+        ReplaceTextKind::PreserveCase => {
+          let first_char = matched_text.chars().next().unwrap_or_default();
+          if matched_text.chars().all(char::is_uppercase) {
+            replace_text_state.text.to_uppercase()
+          } else if first_char.is_uppercase() {
+            replace_text_state
+              .text
+              .chars()
+              .enumerate()
+              .map(|(i, rc)| if i == 0 { rc.to_uppercase().to_string() } else { rc.to_lowercase().to_string() })
+              .collect::<String>()
+          } else {
+            replace_text_state.text.to_lowercase()
+          }
+        },
+        ReplaceTextKind::Simple => replace_text_state.text.to_string(),
+        #[cfg(feature = "ast_grep")]
+        ReplaceTextKind::AstGrep => panic!("AST-grep should not be handled here"),
+      }
+    })
+    .to_string();
+
+  fs::write(file_path, new_content).expect("Unable to write file");
+}

--- a/src/ui/help_display_dialog.rs
+++ b/src/ui/help_display_dialog.rs
@@ -58,7 +58,7 @@ impl StatefulWidget for HelpDisplayDialogWidget {
     let text = self.tabs[self.active_tab].content.clone();
 
     let width = 80;
-    let height = 10;
+    let height = 15;
 
     let lines = Text::from(text);
     let text_widget = Paragraph::new(lines)


### PR DESCRIPTION
This PR introduces a new functionality to replace line by line and file by file
- [x] Replace file by file
- [x] Replace line by line
- [x] Fixes a regression on other mode combinations (eg: Match Whole Word with Preserve Case)
- [x] Documentation
