### PR TITLE
Fix regex search

### DIFF
--- a/src/components/preview.rs
+++ b/src/components/preview.rs
@@ -169,7 +169,10 @@ impl Preview {
               spans.push(Span::raw(common_suffix));
             }
           } else {
-            let re = get_search_regex(matched_text, search_kind);
+            let re = regex::RegexBuilder::new(&regex::escape(matched_text))
+              .case_insensitive(false)
+              .build()
+              .expect("Invalid regex");
             let mut last_match_end = 0;
 
             for cap in re.captures_iter(matched_text) {

--- a/src/redux/utils.rs
+++ b/src/redux/utils.rs
@@ -93,7 +93,10 @@ pub fn get_search_regex(search_text: &str, search_kind: &SearchTextKind) -> rege
       RegexBuilder::new(&format!(r"\b{escaped_search_text}\b")).case_insensitive(false).build().expect("Invalid regex")
     },
     SearchTextKind::Regex => {
-      RegexBuilder::new(&escaped_search_text).case_insensitive(true).build().expect("Invalid regex")
+      RegexBuilder::new(search_text)
+        .case_insensitive(true)
+        .build()
+        .unwrap_or_else(|_| RegexBuilder::new(r"(a)^").build().unwrap())
     },
     #[cfg(feature = "ast_grep")]
     SearchTextKind::AstGrep => unreachable!("AST Grep doesn't use regex"),


### PR DESCRIPTION
Regex-based search has been broken since commit 429e2db.

While file searching and preview still work correctly, attempting to perform a replace operation silently fails—despite a success message being shown.

The issue lies in the **get_search_regex** function, which escapes the regex pattern in the same way it does for simple (non-regex) searches. 

However, simply fixing **get_search_regex** also breaks the preview: the file content is shown without any diffs. This happens because the diff is calculated using **get_search_regex**, with **SearchTextKind** from the state and the matched substring used as the pattern.

Instead, when generating the diff, we should use the matched substring directly as the regex pattern—without passing it through **get_search_regex**.
