### PR TITLE
Fix displayed total matches

### DIFF
--- a/src/redux/reducer.rs
+++ b/src/redux/reducer.rs
@@ -145,8 +145,8 @@ pub fn reducer(state: State, action: Action) -> State {
       if file_index < new_search_result.list.len() {
         let file_result = &mut new_search_result.list[file_index];
         if line_index < file_result.matches.len() {
-          file_result.matches.remove(line_index);
-          file_result.total_matches -= 1;
+          let deleted_match = file_result.matches.remove(line_index);
+          file_result.total_matches -= deleted_match.submatches.len();
 
           if file_result.matches.is_empty() {
             new_search_result.list.remove(file_index);

--- a/src/redux/thunk/remove_line_from_file.rs
+++ b/src/redux/thunk/remove_line_from_file.rs
@@ -33,8 +33,8 @@ where
     if self.file_index < search_list.list.len() {
       let file_result = &mut search_list.list[self.file_index];
       if self.line_index < file_result.matches.len() {
-        file_result.matches.remove(self.line_index);
-        file_result.total_matches -= 1;
+        let deleted_match = file_result.matches.remove(self.line_index);
+        file_result.total_matches -= deleted_match.submatches.len();
 
         if file_result.matches.is_empty() {
           search_list.list.remove(self.file_index);


### PR DESCRIPTION
This commit changes how file_result.total_matches
is decremented on line delete and replace. If
previously it would be decremented by 1 in both
cases, then now submatches.len() of a deleted
match is used.

This fixes a bug when displayed total matches
would become inaccurate when deleting or replacing a line with multiple matches;